### PR TITLE
User should be able to delete their account

### DIFF
--- a/run.py
+++ b/run.py
@@ -207,6 +207,21 @@ def edit_user_profile(user_id):
         flash('Wrong password!', 'danger')
         return redirect(f'/users/{user.id}/edit')
 
+@app.route('/users/delete', methods=["POST"])
+def delete_user():
+    """Delete user."""
+
+    if not g.user:
+        flash("Access unauthorized.", "danger")
+        return redirect("/")
+
+    do_logout()
+
+    db.session.delete(g.user)
+    db.session.commit()
+
+    return redirect("/signup")
+
 ########################################################
 # Homepage:
 

--- a/tests/test_user_views.py
+++ b/tests/test_user_views.py
@@ -205,3 +205,22 @@ class UserViewsTestCase(TestCase):
             self.assertEqual(updated_user.first_name, "NEW_FIRST_NAME")
             self.assertEqual(updated_favorites.game1, "Halo")
             self.assertEqual(resp.status_code, 302)
+
+    def test_delete_user(self):
+        """Can a user delete their account?"""
+
+        with self.client as c:
+            resp = c.post("/users/delete", follow_redirects=True)
+            html = resp.get_data(as_text=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("Access unauthorized.", html)
+        
+        with c.session_transaction() as sess:
+                sess[CURR_USER_KEY] = self.uid1
+
+        # Check that the user is deleted from db
+        resp = c.post("/users/delete")
+
+        user_test = User.query.filter_by(id=10).one_or_none()
+        self.assertEqual(resp.status_code, 302)
+        self.assertFalse(user_test)


### PR DESCRIPTION
### What does this PR do?
- This Pull Request implements the feature for a user to delete their account.
- This PR closes #21 
### Description of Task to be completed
- User should be able to delete their account
### How should this be manually tested?
- From the user's profile, click "Delete Profile". It should redirect to `/signup`. Verify the account is deleted by attempting to login again.

https://user-images.githubusercontent.com/76837421/131244526-14b4f766-9598-418b-a0f1-2fb09eca90d8.mov